### PR TITLE
Feature/37 save qr

### DIFF
--- a/SpotifyParty/Base.lproj/Main.storyboard
+++ b/SpotifyParty/Base.lproj/Main.storyboard
@@ -486,18 +486,18 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
+                            <pickerView contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wMH-2A-pJf">
+                                <rect key="frame" x="164" y="300" width="250" height="136"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                            </pickerView>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gkk-yV-K7C">
-                                <rect key="frame" x="184" y="596" width="46" height="56"/>
+                                <rect key="frame" x="184" y="650" width="46" height="56"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Create"/>
                                 <connections>
                                     <action selector="createEventPressed:" destination="y8y-YB-tZC" eventType="touchUpInside" id="qpN-1p-WJv"/>
                                 </connections>
                             </button>
-                            <pickerView contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wMH-2A-pJf">
-                                <rect key="frame" x="164" y="300" width="250" height="136"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                            </pickerView>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <gestureRecognizers/>
@@ -556,9 +556,13 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CMR-zC-UPN">
+                            <imageView clipsSubviews="YES" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CMR-zC-UPN">
                                 <rect key="frame" x="107" y="315" width="200" height="200"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <gestureRecognizers/>
+                                <connections>
+                                    <outletCollection property="gestureRecognizers" destination="cnR-Uh-Yx2" appends="YES" id="3Wl-EP-SB6"/>
+                                </connections>
                             </imageView>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kUH-eb-vUU">
                                 <rect key="frame" x="144" y="758" width="126" height="30"/>
@@ -577,6 +581,11 @@
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="2f7-qB-B2z" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+                <pongPressGestureRecognizer allowableMovement="10" minimumPressDuration="0.5" id="cnR-Uh-Yx2">
+                    <connections>
+                        <action selector="longPressedQR:" destination="Mwv-39-O8v" id="C6R-27-oUj"/>
+                    </connections>
+                </pongPressGestureRecognizer>
             </objects>
             <point key="canvasLocation" x="-184" y="3252"/>
         </scene>

--- a/SpotifyParty/Info.plist
+++ b/SpotifyParty/Info.plist
@@ -35,6 +35,8 @@
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>$(PRODUCT_NAME) wants to acces your photo library</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>

--- a/SpotifyParty/View Controllers/HostViewController.m
+++ b/SpotifyParty/View Controllers/HostViewController.m
@@ -29,6 +29,22 @@
     
 }
 
+- (IBAction)longPressedQR:(id)sender {
+    
+    // Add the qr image as an activity item and present the sharing view controller
+    NSArray *activityItems = @[self.qrImageView.image];
+    UIActivityViewController *activityViewControntroller = [[UIActivityViewController alloc] initWithActivityItems:activityItems applicationActivities:nil];
+    
+    activityViewControntroller.excludedActivityTypes = @[];
+    if (UI_USER_INTERFACE_IDIOM()  == UIUserInterfaceIdiomPad) {
+        activityViewControntroller.popoverPresentationController.sourceView = self.view;
+        activityViewControntroller.popoverPresentationController.sourceRect = CGRectMake(self.view.bounds.size.width/2, self.view.bounds.size.height/4, 0, 0);
+    }
+    
+    [self presentViewController:activityViewControntroller animated:true completion:nil];
+}
+
+
 #pragma mark - Navigation
 
 - (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
@@ -41,7 +57,5 @@
     }
 
 }
-
-
 
 @end


### PR DESCRIPTION
The user can now long press the QR image for his event to save it as an image or share it in social media. 

<img src='http://g.recordit.co/oOcmBJOEJ3.gif' title='Video Walkthrough' width='' alt='Video Walkthrough' />

Closes #37 